### PR TITLE
Link to YourKit had an extra parentheses at the end so it was pointing to 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Copyright &copy; 2016 [Peter Taoussanis].
 
 <!--- Unique links -->
 [Edward Tufte]: https://en.wikipedia.org/wiki/Edward_Tufte
-[YourKit]: http://www.yourkit.com/)
+[YourKit]: http://www.yourkit.com
 [JProfiler]: http://www.ej-technologies.com/products/jprofiler/overview.html
 [VisualVM]: http://docs.oracle.com/javase/6/docs/technotes/guides/visualvm/index.html
 [@ptaoussanis/Timbre]: https://github.com/ptaoussanis/timbre

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Copyright &copy; 2016 [Peter Taoussanis].
 
 <!--- Unique links -->
 [Edward Tufte]: https://en.wikipedia.org/wiki/Edward_Tufte
-[YourKit]: http://www.yourkit.com
+[YourKit]: https://www.yourkit.com/
 [JProfiler]: http://www.ej-technologies.com/products/jprofiler/overview.html
 [VisualVM]: http://docs.oracle.com/javase/6/docs/technotes/guides/visualvm/index.html
 [@ptaoussanis/Timbre]: https://github.com/ptaoussanis/timbre


### PR DESCRIPTION
Link to YourKit had an extra parentheses at the end so it was pointing to 404 page on their site. 