### PR TITLE
Patch to display minutes in format-stats.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,12 +12,12 @@
 
   :dependencies
   [[org.clojure/clojure "1.7.0"]
-   [com.taoensso/encore "2.88.0"]]
+   [com.taoensso/encore "2.89.0"]]
 
   :plugins
   [[lein-pprint    "1.1.2"]
    [lein-ancient   "0.6.10"]
-   [lein-codox     "0.10.2"]
+   [lein-codox     "0.10.3"]
    [lein-cljsbuild "1.1.4"]]
 
   :profiles
@@ -26,10 +26,10 @@
    :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9      {:dependencies [[org.clojure/clojure "1.9.0-alpha13"]]}
    :test     {:dependencies [[org.clojure/test.check "0.9.0"]]}
-   :provided {:dependencies [[org.clojure/clojurescript "1.9.293"]]}
+   :provided {:dependencies [[org.clojure/clojurescript "1.9.473"]]}
    :dev
    [:1.9 :test :server-jvm
-    {:dependencies [[com.taoensso/timbre "4.7.4"]]}]}
+    {:dependencies [[com.taoensso/timbre "4.8.0"]]}]}
 
   :cljsbuild
   {:test-commands

--- a/src/taoensso/tufte.cljc
+++ b/src/taoensso/tufte.cljc
@@ -570,10 +570,11 @@
 (defn- ft [nanosecs]
   (let [ns (long nanosecs)] ; Truncate any fractionals
     (cond
-      (>= ns 1000000000) (str (enc/round2 (/ ns 1000000000))  "s") ; 1e9
-      (>= ns    1000000) (str (enc/round2 (/ ns    1000000)) "ms") ; 1e6
-      (>= ns       1000) (str (enc/round2 (/ ns       1000)) "μs") ; 1e3
-      :else              (str                ns              "ns"))))
+      (>= ns 60000000000) (str (enc/round2 (/ ns 60000000000))  "m")
+      (>= ns 1000000000)  (str (enc/round2 (/ ns  1000000000))  "s") ; 1e9
+      (>= ns    1000000)  (str (enc/round2 (/ ns     1000000)) "ms") ; 1e6
+      (>= ns       1000)  (str (enc/round2 (/ ns        1000)) "μs") ; 1e3
+      :else               (str                ns               "ns"))))
 
 (defn format-stats
   ([stats]


### PR DESCRIPTION
Display time in minutes when duration is >= 1 minute.

I have some computations that take hours. It is difficult to comprehend the output with the current maximum granularity of seconds.