### PR TITLE
Add p-> and p->> macros

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,12 +12,12 @@
 
   :dependencies
   [[org.clojure/clojure "1.7.0"]
-   [com.taoensso/encore "2.88.0"]]
+   [com.taoensso/encore "2.89.0"]]
 
   :plugins
   [[lein-pprint    "1.1.2"]
    [lein-ancient   "0.6.10"]
-   [lein-codox     "0.10.2"]
+   [lein-codox     "0.10.3"]
    [lein-cljsbuild "1.1.4"]]
 
   :profiles
@@ -26,10 +26,10 @@
    :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9      {:dependencies [[org.clojure/clojure "1.9.0-alpha13"]]}
    :test     {:dependencies [[org.clojure/test.check "0.9.0"]]}
-   :provided {:dependencies [[org.clojure/clojurescript "1.9.293"]]}
+   :provided {:dependencies [[org.clojure/clojurescript "1.9.473"]]}
    :dev
    [:1.9 :test :server-jvm
-    {:dependencies [[com.taoensso/timbre "4.7.4"]]}]}
+    {:dependencies [[com.taoensso/timbre "4.8.0"]]}]}
 
   :cljsbuild
   {:test-commands


### PR DESCRIPTION
This PR adds a few convenience macros for profiling forms within a thread form individually. Without these macros, I have to either 1) wrap threaded forms in an anonymous fn that calls p, or 2) insert a call to p after each fn to profile:

```
;; Works, but requires ugly code modification
(->> (range 10)
     (map inc)
     ((fn [x] (p ::myreduce (reduce + x))))
     even?)

;; Not what I want
;; This actually profiles everything above the call to p due to the way the thread macro expands
(->> (range 10)
     (map inc)
     (reduce +)
     (p :myreduce)
     even?)
```

With `p->` and `p->>`, I can wrap the whole thread form in a single profiling fn with a unique ID, and each form gets wrapped in an anonymous fn that calls p with a unique auto-generated ID based on the parent ID, the form position, and the fn or data in the form.
```
user=> (profile {} (p-> :mythread (-> {:foo 1} (assoc :bar 2) (update :foo inc))))

                    pId      nCalls       Min        Max       MAD      Mean   Time% Time
::mythread-form2-update           1   83.91μs    83.91μs       0ns   83.91μs       7 83.91μs
 ::mythread-form1-assoc           1   20.29μs    20.29μs       0ns   20.29μs       2 20.29μs
  ::mythread-form0-data           1    1.03μs     1.03μs       0ns    1.03μs       0 1.03μs
             Clock Time                                                          100 1.21ms
         Accounted Time                                                            9 105.23μs

{:bar 2 :foo 2}

user=> (profile {} (p->> :mythread (->> (range 100000) (map dec) (reduce +) even?)))

                    pId      nCalls       Min        Max       MAD      Mean   Time% Time
::mythread-form2-reduce           1    6.39ms     6.39ms       0ns    6.39ms      85 6.39ms
 ::mythread-form3-even?           1   25.88μs    25.88μs       0ns   25.88μs       0 25.88μs
   ::mythread-form1-map           1   21.64μs    21.64μs       0ns   21.64μs       0 21.64μs
 ::mythread-form0-range           1    8.77μs     8.77μs       0ns    8.77μs       0 8.77μs
             Clock Time                                                          100 7.51ms
         Accounted Time                                                           86 6.44ms

true
```
