### PR TITLE
Align pid left

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,12 +12,12 @@
 
   :dependencies
   [[org.clojure/clojure "1.7.0"]
-   [com.taoensso/encore "2.94.0"]]
+   [com.taoensso/encore "2.100.0"]]
 
   :plugins
   [[lein-pprint    "1.2.0"]
    [lein-ancient   "0.6.15"]
-   [lein-codox     "0.10.3"]
+   [lein-codox     "0.10.5"]
    [lein-cljsbuild "1.1.7"]]
 
   :profiles
@@ -26,7 +26,7 @@
    :1.8      {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9      {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :test     {:dependencies [[org.clojure/test.check "0.9.0"]]}
-   :provided {:dependencies [[org.clojure/clojurescript "1.10.238"]]}
+   :provided {:dependencies [[org.clojure/clojurescript "1.10.339"]]}
    :dev
    [:1.9 :test :server-jvm
     {:dependencies [[com.taoensso/timbre "4.10.0"]]}]}

--- a/src/taoensso/tufte.cljc
+++ b/src/taoensso/tufte.cljc
@@ -216,9 +216,10 @@
 
 (defn add-basic-println-handler!
   "Adds a simple handler that logs `profile` stats output with `println`."
-  [{:keys [ns-pattern format-columns]
+  [{:keys [ns-pattern format-columns format-id-fn]
     :or   {ns-pattern "*"
-           format-columns stats/all-format-columns}}]
+           format-columns stats/all-format-columns
+           format-id-fn (fn [id] (str id))}}]
 
   (enc/have? [:el stats/all-format-columns] :in format-columns)
   (add-handler! :basic-println
@@ -229,7 +230,7 @@
           (str
             (when ?id   (str "\nid: "   ?id))
             (when ?data (str "\ndata: " ?data))
-            "\n" (format-pstats pstats {:columns format-columns})))))))
+            "\n" (format-pstats pstats {:columns format-columns :format-id-fn format-id-fn})))))))
 
 (comment (add-basic-println-handler! {}))
 

--- a/src/taoensso/tufte.cljc
+++ b/src/taoensso/tufte.cljc
@@ -533,7 +533,8 @@
   (when ps
     (let [{:keys [clock stats]} (if (instance? PStats ps) @ps ps)
           sort-fn (fn [id m] (get m :sum))]
-      (stats/format-stats (get clock :total) stats sort-fn columns))))
+      (stats/format-stats (get clock :total) stats {:sort-fn sort-fn
+                                                    :columns columns}))))
 
 (comment
   ;; [:n-calls :min :p50 :p90 :p95 :p99 :max :mean :mad :clock :total]

--- a/src/taoensso/tufte.cljc
+++ b/src/taoensso/tufte.cljc
@@ -229,7 +229,7 @@
           (str
             (when ?id   (str "\nid: "   ?id))
             (when ?data (str "\ndata: " ?data))
-            "\n" (format-pstats pstats format-columns)))))))
+            "\n" (format-pstats pstats {:columns format-columns})))))))
 
 (comment (add-basic-println-handler! {}))
 

--- a/src/taoensso/tufte.cljc
+++ b/src/taoensso/tufte.cljc
@@ -529,12 +529,15 @@
   "Formats given pstats to a string table.
     Accounted < Clock => Some work was done that wasn't tracked by any p forms.
     Accounted > Clock => Nested p forms, and/or parallel threads."
-  [ps & [{:keys [columns] :or {columns stats/all-format-columns}}]]
+  [ps & [{:keys [columns format-id-fn]
+          :or   {columns stats/all-format-columns
+                 format-id-fn (fn [id] (str id))}}]]
   (when ps
     (let [{:keys [clock stats]} (if (instance? PStats ps) @ps ps)
           sort-fn (fn [id m] (get m :sum))]
       (stats/format-stats (get clock :total) stats {:sort-fn sort-fn
-                                                    :columns columns}))))
+                                                    :columns columns
+                                                    :format-id-fn format-id-fn}))))
 
 (comment
   ;; [:n-calls :min :p50 :p90 :p95 :p99 :max :mean :mad :clock :total]

--- a/src/taoensso/tufte/stats.cljc
+++ b/src/taoensso/tufte/stats.cljc
@@ -245,9 +245,10 @@
 (defn format-stats
   "Returns a formatted table string for given `{<id> <stats>}` map.
   Assumes nanosecond clock, stats based on profiling id'd nanosecond times."
-  [clock-total id-stats {:keys [sort-fn columns]
-                         :or   {sort-fn (fn [id m] (get m :sum))
-                                columns all-format-columns}}]
+  [clock-total id-stats {:keys [sort-fn columns format-id-fn]
+                         :or   {sort-fn      (fn [id m] (get m :sum))
+                                columns      all-format-columns
+                                format-id-fn (fn [id] (str id))}}]
   (when id-stats
     (enc/have? [:el all-format-columns] :in columns)
     (let [clock-total (long clock-total)
@@ -266,7 +267,7 @@
           ^long max-id-width
           (reduce-kv
             (fn [^long acc k v]
-              (let [c (count (str k))]
+              (let [c (count (format-id-fn k))]
                 (if (> c acc) c acc)))
             9 ; (count "Accounted")
             id-stats)
@@ -302,7 +303,7 @@
               sum  (get s :sum)
               mean (get s :mean)]
 
-          (append-col :id (str id))
+          (append-col :id (format-id-fn id))
           (doseq [column columns]
             (enc/sb-append sb " ")
             (case column

--- a/src/taoensso/tufte/stats.cljc
+++ b/src/taoensso/tufte/stats.cljc
@@ -272,7 +272,8 @@
             9 ; (count "Accounted")
             id-stats)
 
-          column->pattern {:id      {:heading "pId"    :min-width max-id-width}
+          column->pattern {:id      {:heading "pId"    :min-width max-id-width
+                                                       :align :left}
                            :n-calls {:heading "nCalls"}
                            :min     {:heading "Min"}
                            :p50     {:heading "50% ≤"}
@@ -287,7 +288,14 @@
 
           sb (enc/str-builder "")
 
-          append-col (fn [column s] (enc/sb-append sb (enc/format (str "%" (get-in column->pattern [column :min-width] 10) "s") s)))]
+          append-col (fn [column s]
+                       (let [{:keys [min-width align]
+                              :or {min-width 10 align :right}} (get column->pattern column)]
+                         (enc/sb-append sb
+                           (enc/format (str "%" (case align :left "-" "")
+                                                min-width
+                                                "s")
+                                       s))))]
 
       ; Write header rows
       (doseq [column (into [:id] columns)]

--- a/src/taoensso/tufte/stats.cljc
+++ b/src/taoensso/tufte/stats.cljc
@@ -220,8 +220,8 @@
   (defn- fmt [nanosecs]
     (let [ns (double nanosecs)]
       (cond
-        (>= ns 6e10) (str (round2 (/ ns 6e10)) "m")
-        (>= ns 1e9)  (str (round2 (/ ns 1e9))  "s")
+        (>= ns 6e10) (str (round2 (/ ns 6e10)) "m ")
+        (>= ns 1e9)  (str (round2 (/ ns 1e9))  "s ")
         (>= ns 1e6)  (str (round2 (/ ns 1e6))  "ms")
         (>= ns 1e3)  (str (round2 (/ ns 1e3))  "μs")
         :else        (str (round2    ns)       "ns")))))

--- a/src/taoensso/tufte/stats.cljc
+++ b/src/taoensso/tufte/stats.cljc
@@ -219,8 +219,8 @@
   (defn- fmt [nanosecs]
     (let [ns (double nanosecs)]
       (cond
-        (>= ns 6e10) (str (round2 (/ ns 6e10)) "m ")
-        (>= ns 1e9)  (str (round2 (/ ns 1e9))  "s ")
+        (>= ns 6e10) (str (round2 (/ ns 6e10)) "m")
+        (>= ns 1e9)  (str (round2 (/ ns 1e9))  "s")
         (>= ns 1e6)  (str (round2 (/ ns 1e6))  "ms")
         (>= ns 1e3)  (str (round2 (/ ns 1e3))  "μs")
         :else        (str (round2    ns)       "ns")))))
@@ -229,11 +229,15 @@
   (format "%.2f" 40484.005)
   (fmt 2387387870))
 
+
+(def all-columns [:n-calls :min :p50 :p90 :p95 :p99 :max :mean :mad :clock :total])
+
 (defn format-stats
   "Returns a formatted table string for given `{<id> <stats>}` map.
   Assumes nanosecond clock, stats based on profiling id'd nanosecond times."
-  ([clock-total id-stats        ] (format-stats clock-total id-stats (fn [id m] (get m :sum))))
-  ([clock-total id-stats sort-fn]
+  ([clock-total id-stats] (format-stats clock-total id-stats (fn [id m] (get m :sum))))
+  ([clock-total id-stats sort-fn] (format-stats clock-total id-stats sort-fn all-columns))
+  ([clock-total id-stats sort-fn columns]
    (when id-stats
      (let [clock-total (long clock-total)
            ^long accounted-total
@@ -260,62 +264,90 @@
           (let [sb
                 (reduce
                   (fn [acc id]
-                    (let [s     (get id-stats id)
-                          sum   (get s :sum)
-                          mean  (get s :mean)]
+                    (let [s (get id-stats id)
+                          sum (get s :sum)
+                          mean (get s :mean)]
                       (enc/sb-append acc
-                        (str
-                          {:id    id
-                           :n-calls    (get s :n)
-                           :min   (fmt (get s :min))
-                           :p50   (fmt (get s :p50))
-                           :p90   (fmt (get s :p90))
-                           :p95   (fmt (get s :p95))
-                           :p99   (fmt (get s :p99))
-                           :max   (fmt (get s :max))
-                           :mean  (fmt mean)
-                           :mad   (str "±" (perc (get s :mad) mean))
-                           :total (fmt  sum)
-                           :clock (perc sum clock-total)}
-                          "\n"))))
+                                     (str
+                                       (select-keys {:id      id
+                                                     :n-calls (get s :n)
+                                                     :min     (fmt (get s :min))
+                                                     :p50     (fmt (get s :p50))
+                                                     :p90     (fmt (get s :p90))
+                                                     :p95     (fmt (get s :p95))
+                                                     :p99     (fmt (get s :p99))
+                                                     :max     (fmt (get s :max))
+                                                     :mean    (fmt mean)
+                                                     :mad     (str "±" (perc (get s :mad) mean))
+                                                     :total   (fmt sum)
+                                                     :clock   (perc sum clock-total)} columns)
+                                       "\n"))))
                   (enc/str-builder)
                   sorted-ids)]
 
             (enc/sb-append sb "\n")
             (enc/sb-append sb (str "Accounted: (" (perc accounted-total clock-total) ") " (fmt accounted-total) "\n"))
             (enc/sb-append sb (str "Clock: (100%) " (fmt clock-total) "\n"))
-            (str           sb))
+            (str sb))
 
           :clj
-          (let [n-pattern (str "%" max-id-width "s %,10d %10s %10s %10s %10s %10s %10s %10s %5s %11s %7s" "\n")
-                s-pattern (str "%" max-id-width  "s %10s %10s %10s %10s %10s %10s %10s %10s %5s %11s %7s" "\n")
-                sb
-                (reduce
-                  (fn [acc id]
-                    (let [s    (get id-stats id)
-                          sum  (get s :sum)
-                          mean (get s :mean)]
-                      (enc/sb-append acc
-                        (format n-pattern id
-                               (get s :n)
-                          (fmt (get s :min))
-                          (fmt (get s :p50))
-                          (fmt (get s :p90))
-                          (fmt (get s :p95))
-                          (fmt (get s :p99))
-                          (fmt (get s :max))
-                          (fmt mean)
-                          (str "±" (perc (get s :mad) mean))
-                          (fmt  sum)
-                          (perc sum clock-total)))))
+          (let [column->pattern {:id      {:n (str "%" max-id-width "s") :s (str "%" max-id-width "s") :heading "pId"}
+                                 :n-calls {:n "%,10d" :s "%10s" :heading "nCalls"}
+                                 :min     {:heading "Min"}
+                                 :p50     {:heading "50% ≤"}
+                                 :p90     {:heading "90% ≤"}
+                                 :p95     {:heading "95% ≤"}
+                                 :p99     {:heading "99% ≤"}
+                                 :max     {:heading "Max"}
+                                 :mean    {:heading "Mean"}
+                                 :mad     {:n "%5s" :s "%5s" :heading "MAD"}
+                                 :total   {:n "%6s" :s "%6s" :heading "Total"}
+                                 :clock   {:heading "Clock"}}
+                ^StringBuilder sb (enc/str-builder "")
+                format-n-append (fn [column s] (enc/sb-append sb (format (get-in column->pattern [column :n] "%10s") s)))
+                format-s-append (fn [column s] (enc/sb-append sb (format (get-in column->pattern [column :s] "%10s") s)))]
 
-                  ;; (enc/str-builder (str (format s-pattern "pId" "nCalls" "Min" "p50" "p90" "p95" "p99" "Max" "Mean" "MAD" "Total" "Clock" ) "\n"))
-                  (enc/str-builder (str (format s-pattern "pId" "nCalls" "Min" "50% ≤" "90% ≤" "95% ≤" "99% ≤" "Max" "Mean" "MAD" "Total" "Clock" ) "\n"))
-                  sorted-ids)]
+            ; Write headers
+            (doseq [column (into [:id] columns)]
+              (when-not (= :id column)
+                (enc/sb-append sb " "))
+              (format-s-append column (get-in column->pattern [column :heading])))
+            (enc/sb-append sb "\n\n")
 
+            ; Write numbers
+            (doseq [id sorted-ids]
+              (let [s (get id-stats id)
+                    sum (get s :sum)
+                    mean (get s :mean)]
+                (format-n-append :id id)
+                (doseq [column columns]
+                  (enc/sb-append sb " ")
+                  (case column :n-calls (format-n-append column (get s :n))
+                               :mean  (format-n-append column (fmt mean))
+                               :mad (format-n-append column (str "±" (perc (get s :mad) mean)))
+                               :total (format-n-append column (perc sum clock-total))
+                               :clock (format-n-append column (fmt sum))
+                               (format-n-append column (fmt (get s column)))))
+                (enc/sb-append sb "\n")))
+
+            ; Write Accounted
             (enc/sb-append sb "\n")
-            (enc/sb-append sb (format s-pattern "Accounted" "" "" "" "" "" "" "" "" "" (fmt accounted-total) (perc accounted-total clock-total)))
-            (enc/sb-append sb (format s-pattern "Clock"     "" "" "" "" "" "" "" "" "" (fmt clock-total)     "100%"))
+            (format-s-append :id "Accounted")
+            (doseq [column columns]
+              (enc/sb-append sb " ")
+              (case column :total (format-s-append column (perc accounted-total clock-total))
+                           :clock (format-s-append column (fmt accounted-total))
+                           (format-s-append column "")))
+
+            ; Write Clock
+            (enc/sb-append sb "\n")
+            (format-s-append :id "Clock")
+            (doseq [column columns]
+              (enc/sb-append sb " ")
+              (case column :total (format-s-append column "100%")
+                           :clock (format-s-append column (fmt clock-total))
+                           (format-s-append column "")))
+            (enc/sb-append sb "\n")
             (str sb)))))))
 
 (comment

--- a/test/taoensso/tufte_tests.clj
+++ b/test/taoensso/tufte_tests.clj
@@ -449,6 +449,26 @@
                   (->> (tufte/format-pstats data {:columns [:n-calls :mean :clock :total]})
                        (str/split-lines)
                        (remove empty?))))))
+  (test/testing "format-stats with namespaced symbols and custom id-formatter"
+    (let [data {:clock {:total 15},
+                :stats {:foo/bar {:n 10000
+                                  :min 1
+                                  :p50 2
+                                  :p90 3
+                                  :p95 4
+                                  :p99 5
+                                  :max 6
+                                  :mean 7
+                                  :mad 5.062294599999648
+                                  :sum 15}}}]
+      (test/is (= ["      pId     nCalls       Mean      Clock  Total"
+                   "      bar     10,000     7.00ns    15.00ns   100%"
+                   "Accounted                          15.00ns   100%"
+                   "    Clock                          15.00ns   100%"]
+                  (->> (tufte/format-pstats data {:columns      [:n-calls :mean :clock :total]
+                                                  :format-id-fn name})
+                       (str/split-lines)
+                       (remove empty?))))))
   (test/testing "Format seconds"
     (let [data {:clock {:total 2e9},
                 :stats {:foo {:n 1

--- a/test/taoensso/tufte_tests.clj
+++ b/test/taoensso/tufte_tests.clj
@@ -430,6 +430,25 @@
                   (->> (tufte/format-pstats data {:columns [:n-calls :mean :clock :total]})
                        (str/split-lines)
                        (remove empty?))))))
+  (test/testing "format-stats with namespaced symbols"
+    (let [data {:clock {:total 15},
+                :stats {:foo/bar {:n 10000
+                                  :min 1
+                                  :p50 2
+                                  :p90 3
+                                  :p95 4
+                                  :p99 5
+                                  :max 6
+                                  :mean 7
+                                  :mad 5.062294599999648
+                                  :sum 15}}}]
+      (test/is (= ["      pId     nCalls       Mean      Clock  Total"
+                   " :foo/bar     10,000     7.00ns    15.00ns   100%"
+                   "Accounted                          15.00ns   100%"
+                   "    Clock                          15.00ns   100%"]
+                  (->> (tufte/format-pstats data {:columns [:n-calls :mean :clock :total]})
+                       (str/split-lines)
+                       (remove empty?))))))
   (test/testing "Format seconds"
     (let [data {:clock {:total 2e9},
                 :stats {:foo {:n 1

--- a/test/taoensso/tufte_tests.clj
+++ b/test/taoensso/tufte_tests.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.test    :as test  :refer [is]]
    [taoensso.tufte  :as tufte :refer [profiled profile p]]
-   [taoensso.encore :as enc])
+   [taoensso.encore :as enc]
+   [clojure.string  :as str])
   (:import [taoensso.tufte.impl PState PData PStats]))
 
 (comment
@@ -400,3 +401,32 @@
       (is (= (get-in @@pd [:stats :foo :n]) 1))
       (is (= (get-in @@pd [:stats :bar :n]) 1))
       (is (= (get-in @@pd [:stats :baz :n]) 1)))))
+
+(test/deftest format-stats-test
+  (test/testing "Basic format-stats"
+    (let [data {:clock {:total 15},
+                :stats {:foo {:n 10000
+                              :min 1
+                              :p50 2
+                              :p90 3
+                              :p95 4
+                              :p99 5
+                              :max 6
+                              :mean 7
+                              :mad 5.062294599999648,
+                              :sum 15,
+                              }}}]
+      (test/is (= ["      pId     nCalls        Min      50% ≤      90% ≤      95% ≤      99% ≤        Max       Mean   MAD      Clock  Total"
+                   "     :foo     10,000     1.00ns     2.00ns     3.00ns     4.00ns     5.00ns     6.00ns     7.00ns  ±72%    15.00ns   100%"
+                   "Accounted                                                                                                  15.00ns   100%"
+                   "    Clock                                                                                                  15.00ns   100%"]
+                  (->> (tufte/format-pstats data)
+                       (str/split-lines)
+                       (remove empty?))))
+      (test/is (= ["      pId     nCalls       Mean      Clock  Total"
+                   "     :foo     10,000     7.00ns    15.00ns   100%"
+                   "Accounted                          15.00ns   100%"
+                   "    Clock                          15.00ns   100%"]
+                  (->> (tufte/format-pstats data {:columns [:n-calls :mean :clock :total]})
+                       (str/split-lines)
+                       (remove empty?)))))))

--- a/test/taoensso/tufte_tests.clj
+++ b/test/taoensso/tufte_tests.clj
@@ -429,4 +429,34 @@
                    "    Clock                          15.00ns   100%"]
                   (->> (tufte/format-pstats data {:columns [:n-calls :mean :clock :total]})
                        (str/split-lines)
-                       (remove empty?)))))))
+                       (remove empty?))))))
+  (test/testing "Format seconds"
+    (let [data {:clock {:total 2e9},
+                :stats {:foo {:n 1
+                              :mean 2e9
+                              :sum 2e9}
+                        :bar {:n 1
+                              :mean 15
+                              :sum 15}}}]
+      (test/is (= ["      pId     nCalls       Mean"
+                   "     :foo          1     2.00s "
+                   "     :bar          1    15.00ns"]
+                  (->> (tufte/format-pstats data {:columns [:n-calls :mean]})
+                       (str/split-lines)
+                       (remove empty?)
+                       (take 3))))))
+  (test/testing "Format seconds only"
+    (let [data {:clock {:total 2e9},
+                :stats {:foo {:n 1
+                              :mean 2e9
+                              :sum 2e9}
+                        :bar {:n 1
+                              :mean 1e9
+                              :sum 1e9}}}]
+      (test/is (= ["      pId     nCalls       Mean" ; TODO: It would be better if seconds aligned to Mean properly
+                   "     :foo          1     2.00s " ; Current behaviour looks a little strange.
+                   "     :bar          1     1.00s "]
+                  (->> (tufte/format-pstats data {:columns [:n-calls :mean]})
+                       (str/split-lines)
+                       (remove empty?)
+                       (take 3)))))))


### PR DESCRIPTION
Add `:align` option to `column->pattern` and set `:left` for `:id` column. Addresses #39.