### PR TITLE
Merge pstats compaction

### DIFF
--- a/src/taoensso/tufte.cljc
+++ b/src/taoensso/tufte.cljc
@@ -365,7 +365,7 @@
        - @(merge-pstats ps1 ps2) -> {:stats {:n _ :min _ ...} :clock {:t0 _ :t1 _ :total _}}
 
      Full set of `:stats` keys:
-       :n :min :max :mean :mad :sum :p50 :p90 :p95 :p99
+       :n :min :max :mean :mad :sum :p25 :p50 :p75 :p90 :p95 :p99
 
      Compile-time opts:
        :level    - e/o #{0 1 2 3 4 5} ; Default is `5`
@@ -579,7 +579,7 @@
          (assoc opts :approx-clock? (get clock :approx?)))))))
 
 (comment
-  ;; [:n-calls :min :p50 :p90 :p95 :p99 :max :mean :mad :clock :total]
+  ;; [:n-calls :min :p25 :p50 :p75 :p90 :p95 :p99 :max :mean :mad :clock :total]
   (println
     (str "\n"
       (format-pstats

--- a/src/taoensso/tufte/impl.cljc
+++ b/src/taoensso/tufte/impl.cljc
@@ -166,6 +166,11 @@
 (defn- fast-into [c0 c1] (if (> (count c0) (count c1)) (into c0 c1) (into c1 c0)))
 (comment (fast-into nil nil))
 
+(defn merge-stats-when-needed [stats nmax]
+  (if (<= (count stats) nmax)
+    stats
+    [(reduce stats/merge-stats stats)]))
+
 (defn merge-and-compact [pd1-id-times pd1-id-stats pd2-id-times pd2-id-stats nmax]
   (if pd1-id-times
     (reduce-kv
@@ -184,7 +189,7 @@
             ;; Times need compaction
             (let [stats<times (stats/stats pd2-times)]
               [(assoc pd2-id-times id nil)
-               (assoc pd2-id-stats id (conj pd2-stats stats<times))]))))
+               (assoc pd2-id-stats id (merge-stats-when-needed (conj pd2-stats stats<times) nmax))]))))
       [pd2-id-times pd2-id-stats]
       pd1-id-times)
     (reduce-kv
@@ -195,7 +200,7 @@
           ;; Times need compaction
           (let [stats<times (stats/stats pd2-times)]
             [(assoc pd2-id-times id nil)
-             (assoc pd2-id-stats id (conj (get pd2-id-stats id) stats<times))])))
+             (assoc pd2-id-stats id (merge-stats-when-needed (conj (get pd2-id-stats id) stats<times) nmax))])))
       [pd2-id-times pd2-id-stats]
       pd2-id-times)))
 

--- a/src/taoensso/tufte/stats.cljc
+++ b/src/taoensso/tufte/stats.cljc
@@ -48,6 +48,7 @@
        (aget a (Math/round (* 0.25 max-idx)))
        (aget a (Math/round (* 0.50 max-idx)))
        (aget a (Math/round (* 0.75 max-idx)))
+       (aget a (Math/round (* 0.90 max-idx)))
        (aget a (Math/round (* 0.95 max-idx)))
        (aget a (Math/round (* 0.99 max-idx)))
        (aget a                     max-idx)])))

--- a/src/taoensso/tufte/stats.cljc
+++ b/src/taoensso/tufte/stats.cljc
@@ -38,15 +38,16 @@
   (vec (.-a (sort-longs (rand-vs 10)))))
 
 (defn long-percentiles
-  "Returns ?[min p50 p90 p95 p99 max]"
+  "Returns ?[min p25 p50 p75 p90 p95 p99 max]"
   [longs]
   (let [^longs a (.-a (sort-longs longs))
         max-idx (dec (alength a))]
     (if (< max-idx 0)
       nil
       [(aget a 0)
+       (aget a (Math/round (* 0.25 max-idx)))
        (aget a (Math/round (* 0.50 max-idx)))
-       (aget a (Math/round (* 0.90 max-idx)))
+       (aget a (Math/round (* 0.75 max-idx)))
        (aget a (Math/round (* 0.95 max-idx)))
        (aget a (Math/round (* 0.99 max-idx)))
        (aget a                     max-idx)])))
@@ -95,8 +96,8 @@
 
 (defn stats
   "Given a collection of longs, returns map with keys:
-  #{:n :min :max :sum :mean :mad-sum :mad :p50 :p90 :p95 :p99}, or nil if
-  collection is empty."
+  #{:n :min :max :sum :mean :mad-sum :mad :p25 :p50 :p75 :p90 :p95 :p99}, or nil
+  if collection is empty."
   [longs]
   (when longs
     (let [sorted-longs (sort-longs longs)
@@ -109,11 +110,12 @@
               mad-sum (areduce a i acc 0.0 (+ acc (Math/abs (- (double (aget a i)) mean))))
               mad     (/ (double mad-sum) (double n))
 
-              [vmin p50 p90 p95 p99 vmax] (long-percentiles sorted-longs)]
+              [vmin p25 p50 p75 p90 p95 p99 vmax] (long-percentiles sorted-longs)]
 
           {:n n :min vmin :max vmax :sum sum :mean mean
            :mad-sum mad-sum :mad mad
-           :p50 p50 :p90 p90 :p95 p95 :p99 p99})))))
+           :p25 p25 :p50 p50 :p75 p75
+           :p90 p90 :p95 p95 :p99 p99})))))
 
 (comment (enc/qb 100 (stats v1) (stats v1-sorted))) ; [1604.23 38.3]
 
@@ -130,7 +132,9 @@
              ^long   max0     :max
              ^long   sum0     :sum
              ^double mad-sum0 :mad-sum
+             ^long   p25-0    :p25
              ^long   p50-0    :p50
+             ^long   p75-0    :p75
              ^long   p90-0    :p90
              ^long   p95-0    :p95
              ^long   p99-0    :p99} m0
@@ -140,7 +144,9 @@
              ^long   max1     :max
              ^long   sum1     :sum
              ^double mad-sum1 :mad-sum
+             ^long   p25-1    :p25
              ^long   p50-1    :p50
+             ^long   p75-1    :p75
              ^long   p90-1    :p90
              ^long   p95-1    :p95
              ^long   p99-1    :p99} m1
@@ -167,7 +173,9 @@
 
             ;;; These are pretty rough approximations. More sophisticated
             ;;; approaches not worth the extra cost/effort in our case.
+            p25-2 (Math/round (+ (* n0-ratio (double p25-0)) (* n1-ratio (double p25-1))))
             p50-2 (Math/round (+ (* n0-ratio (double p50-0)) (* n1-ratio (double p50-1))))
+            p75-2 (Math/round (+ (* n0-ratio (double p75-0)) (* n1-ratio (double p75-1))))
             p90-2 (Math/round (+ (* n0-ratio (double p90-0)) (* n1-ratio (double p90-1))))
             p95-2 (Math/round (+ (* n0-ratio (double p95-0)) (* n1-ratio (double p95-1))))
             p99-2 (Math/round (+ (* n0-ratio (double p99-0)) (* n1-ratio (double p99-1))))
@@ -176,7 +184,8 @@
 
         {:n n2 :min min2 :max max2 :sum sum2 :mean mean2
          :mad-sum mad-sum2 :mad mad2
-         :p50 p50-2 :p90 p90-2 :p95 p95-2 :p99 p99-2})
+         :p25 p25-2 :p50 p50-2 :p75 p75-2
+         :p90 p90-2 :p95 p95-2 :p99 p99-2})
       m0)
     m1))
 
@@ -240,7 +249,8 @@
          (str/join ",")
          (str/reverse))))
 
-(def all-format-columns [:n-calls :min :p50 :p90 :p95 :p99 :max :mean :mad :clock :total])
+(def     all-format-columns [:n-calls :min   :p25 :p50   :p75 :p90 :p95 :p99 :max :mean :mad :clock :total])
+(def default-format-columns [:n-calls :min #_:p25 :p50 #_:p75 :p90 :p95 :p99 :max :mean :mad :clock :total])
 
 (def default-format-id-fn (fn [id] (str id)))
 
@@ -260,7 +270,7 @@
   "Returns a formatted table string for given `{<id> <stats>}` map.
   Assumes nanosecond clock, stats based on profiling id'd nanosecond times."
   [clock-total id-stats {:keys [columns sort-fn format-id-fn approx-clock? max-id-width] :as opts
-                         :or   {columns      all-format-columns
+                         :or   {columns      default-format-columns
                                 sort-fn      (fn [m] (get m :sum))
                                 format-id-fn default-format-id-fn}}]
   (when id-stats
@@ -284,7 +294,9 @@
           {:id      {:heading "pId"    :min-width max-id-width :align :left}
            :n-calls {:heading "nCalls"}
            :min     {:heading "Min"}
+           :p25     {:heading "25% ≤"}
            :p50     {:heading "50% ≤"}
+           :p75     {:heading "75% ≤"}
            :p90     {:heading "90% ≤"}
            :p95     {:heading "95% ≤"}
            :p99     {:heading "99% ≤"}

--- a/test/taoensso/tufte_tests.clj
+++ b/test/taoensso/tufte_tests.clj
@@ -219,9 +219,12 @@
 (test/deftest merge-pstats-compaction
   (let [ps (reduce (fn [org _] (tufte/merge-pstats org (second (profiled {:nmax 10} (looped 10 (p :foo))))))
                    nil
-                   (range 0 10))
+                   (range 0 100))
         id-times (.-id_times ^PState (.-pstate_ ^PData (.-pd ^PStats ps)))
-        foo-profiled (first (vals id-times))]
+        id-stats (.-id_stats ^PState (.-pstate_ ^PData (.-pd ^PStats ps)))
+        foo-profiled (first (vals id-times))
+        foo-profiled-stats (first (vals id-stats))]
+    (is (<= (count foo-profiled-stats) 10))
     (is (<= (count foo-profiled) 10))))
 
 (defn add-test-handler! []

--- a/test/taoensso/tufte_tests.clj
+++ b/test/taoensso/tufte_tests.clj
@@ -220,7 +220,7 @@
   (let [ps (reduce (fn [org _] (tufte/merge-pstats org (second (profiled {:nmax 10} (looped 10 (p :foo))))))
                    nil
                    (range 0 10))
-        id-times (.-id_times (.-pstate_ ^PData (.-pd ^PStats ps)))
+        id-times (.-id_times ^PState (.-pstate_ ^PData (.-pd ^PStats ps)))
         foo-profiled (first (vals id-times))]
     (is (<= (count foo-profiled) 10))))
 

--- a/test/taoensso/tufte_tests.clj
+++ b/test/taoensso/tufte_tests.clj
@@ -216,6 +216,14 @@
       (is (= (get-in @ps3 [:stats :tufte/compaction :n]) 20)) ; Merging does uncounted compaction
       )))
 
+(test/deftest merge-pstats-compaction
+  (let [ps (reduce (fn [org _] (tufte/merge-pstats org (second (profiled {:nmax 10} (looped 10 (p :foo))))))
+                   nil
+                   (range 0 10))
+        id-times (.-id_times (.-pstate_ ^PData (.-pd ^PStats ps)))
+        foo-profiled (first (vals id-times))]
+    (is (<= (count foo-profiled) 10))))
+
 (defn add-test-handler! []
   (let [p (promise)]
     (tufte/add-handler! :testing (fn [x] (p x)))


### PR DESCRIPTION
Fixes issue #54

The background for this is that I was running a stats accumulator for the entire span of my application. This eventually led to the pstats instance using all the available memory as compaction was never done. I believe this will fix this issue, both with respect to id-times and id-stats.

Thanks and kind regards.